### PR TITLE
Setup tsconfig link

### DIFF
--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../src/tsconfig.app.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "types": [
       "node"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
     "importHelpers": true,
     "target": "es5",
     "typeRoots": [


### PR DESCRIPTION
Hey, just peeking in and thought this might be helpful. It looks like these tsconfig files need linked up and this one flag set to get `npm start` working.

Based on findings here: https://github.com/storybookjs/storybook/issues/6911
